### PR TITLE
feat: allow different postfix and other inputs and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ jobs:
 
 </details>
 
-Be sure to always append the postfix to your test files. The default input for the `test_file_postfix` is `_test.rego`, per [OPA's best practices](https://www.openpolicyagent.org/docs/latest/policy-testing/#test-format). If you have a different postfix for your test files, you can specify it in the inputs. This is how GitHub Action know what test to run on files.
+Be sure to always append the postfix to your test files. The default input for the `test_file_postfix` is `_test`, per [OPA's best practices](https://www.openpolicyagent.org/docs/latest/policy-testing/#test-format). If you have a different postfix for your test files, you can specify it in the inputs. This is how GitHub Action know what test to run on files.
 
  For example, if you have a file named `my-policy.rego`, you would need a file named `my-policy_test.rego`. It does not matter where the `_test.rego` file is located, just that it is in the root path, meaning that it can be in a subdirectory.
 
@@ -74,7 +74,7 @@ In the example below, all `_test.rego` files' location are valid and will be exe
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
 | `path` | Path to the directory containing OPA Rego files to test | No | `.` (root directory) |
-| `test_file_postfix` | Postfix of the test files to run (e.g. notification.rego <> notification_test.rego) | No | `_test.rego` |
+| `test_file_postfix` | Postfix of the test files to run (e.g. notification.rego <> notification_test.rego) | No | `_test` |
 | `write_pr_comment` | Flag to write a user-friendly PR comment with test results | No | `true` |
 | `pr_comment_title` | Title of the PR comment for test results | No | `🧪 OPA Rego Policy Test Results` |
 | `run_coverage_report` | Flag to run OPA coverage tests and include in PR comment | No | `true` |

--- a/README.md
+++ b/README.md
@@ -37,12 +37,6 @@ name: Spacelift Policy OPA Rego Tests
 
 on:
   pull_request:
-    types:
-      - opened
-      - edited
-      - synchronize
-      - ready_for_review
-      - reopened
     # Optionally only trigger tests on affecting .rego files.
     # paths:
     #   - '**.rego'
@@ -53,7 +47,7 @@ permissions:
   pull-requests: write # required to comment on PRs
 
 jobs:
-  run-opa-tests:
+  opa-tests:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
@@ -62,7 +56,7 @@ jobs:
       - name: Run OPA Rego Tests
         uses: masterpointio/github-action-opa-rego-test@main
         with:
-          test_directory_path: "./config/spacelift-policies" # Path of the directory where the OPA Rego policies are stored. Optional, defaults to `.` which is the root directory.
+          path: "./config/spacelift-policies" # Path of the directory where the OPA Rego policies are stored. Optional, defaults to `.` which is the root directory.
           report_untested_files: true # Flag to check & report Rego files without corresponding test files. Optional, defaults to false.
 ```
 
@@ -77,7 +71,7 @@ In the example below, all `_test.rego` files' location are valid and will be exe
 ### Inputs
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
-| `test_directory_path` | Path to the directory containing OPA Rego files to test | No | `.` (root directory) |
+| `path` | Path to the directory containing OPA Rego files to test | No | `.` (root directory) |
 | `write_pr_comment` | Flag to write a user-friendly PR comment with test results | No | `true` |
 | `pr_comment_title` | Title of the PR comment for test results | No | `🧪 OPA Rego Policy Test Results` |
 | `run_coverage_report` | Flag to run OPA coverage tests and include in PR comment | No | `true` |
@@ -142,3 +136,4 @@ Contributions are welcome! Please feel free to submit a Pull Request or open any
   - one way is to PR comment error occured in the execution of the tests. please tak eal ook at the logs..
 - publish to marketplace
 - release please.
+- clean up bash script. optimization.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ jobs:
 
 </details>
 
-BE SURE TO ALWAYS APPEND THE POSTFIX `_test.rego` TO YOUR TEST FILES! This is how the GitHub Action know what test to run on files. For example, if you have a file named `my-policy.rego`, you would need a file named `my-policy_test.rego`. It does not matter where the `_test.rego` file is located, just that it is in the same directory as the `.rego` file, meaning that it can be in a subdirectory.
+Be sure to always append the postfix to your test files. The default input for the `test_file_postfix` is `_test.rego`. If you have a different postfix for your test files, you can specify it in the inputs. This is how GitHub Action know what test to run on files.
+
+ For example, if you have a file named `my-policy.rego`, you would need a file named `my-policy_test.rego`. It does not matter where the `_test.rego` file is located, just that it is in the root path, meaning that it can be in a subdirectory.
 
 In the example below, all `_test.rego` files' location are valid and will be executed.
 
@@ -72,6 +74,7 @@ In the example below, all `_test.rego` files' location are valid and will be exe
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
 | `path` | Path to the directory containing OPA Rego files to test | No | `.` (root directory) |
+| `test_file_postfix` | Postfix of the test files to run (e.g. notification.rego <> notification_test.rego) | No | `_test.rego` |
 | `write_pr_comment` | Flag to write a user-friendly PR comment with test results | No | `true` |
 | `pr_comment_title` | Title of the PR comment for test results | No | `🧪 OPA Rego Policy Test Results` |
 | `run_coverage_report` | Flag to run OPA coverage tests and include in PR comment | No | `true` |
@@ -137,3 +140,4 @@ Contributions are welcome! Please feel free to submit a Pull Request or open any
 - publish to marketplace
 - release please.
 - clean up bash script. optimization.
+- add outputs

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ jobs:
 
 </details>
 
-Be sure to always append the postfix to your test files. The default input for the `test_file_postfix` is `_test.rego`. If you have a different postfix for your test files, you can specify it in the inputs. This is how GitHub Action know what test to run on files.
+Be sure to always append the postfix to your test files. The default input for the `test_file_postfix` is `_test.rego`, per [OPA's best practices](https://www.openpolicyagent.org/docs/latest/policy-testing/#test-format). If you have a different postfix for your test files, you can specify it in the inputs. This is how GitHub Action know what test to run on files.
 
  For example, if you have a file named `my-policy.rego`, you would need a file named `my-policy_test.rego`. It does not matter where the `_test.rego` file is located, just that it is in the root path, meaning that it can be in a subdirectory.
 

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: 'Path to the directory containing OPA Rego files to test. Default to root directory.'
     required: false
     default: '.'
+  test_file_postfix:
+    description: 'The postfix to use for test files. E.g. notification.rego <> notification_test.rego. Default is "_test".'
+    required: false
+    default: '_test'
   write_pr_comment:
     description: 'Flag to write an user friendly PR comment of the test results. Default of true.'
     required: false
@@ -26,7 +30,7 @@ inputs:
     required: false
     default: true
   report_untested_files:
-    description: 'Check & report in the PR comments of the Rego files that do not have any corresponding test files. For best conventions, append the postfix `_test` in your test file. E.g. `notification.rego` <> `notification_test.rego`'
+    description: 'Check & report in the PR comments of the Rego files that do not have any corresponding test files. For best conventions, append the postfix `_test` (or what you set as the `test_file_postfix` input) for your test file. E.g. `notification.rego` <> `notification_test.rego`'
     required: false
     default: false
 
@@ -43,11 +47,11 @@ runs:
       shell: bash
       run: |
         BASE_DIRECTORY_PATH="${{ inputs.path }}"
-        tests=$(find "$BASE_DIRECTORY_PATH" -type f -name "*_test.rego")
+        tests=$(find "$BASE_DIRECTORY_PATH" -type f -name "*${{ inputs.test_file_postfix }}.rego")
         output=""
         for test in $tests; do
             echo "Running test: $test"
-            base_name=$(basename "$test" _test.rego)
+            base_name=$(basename "$test" "${{ inputs.test_file_postfix }}.rego")
             test_dir=$(dirname "$test")
             impl_file=$(find "$test_dir" "$test_dir/.." -maxdepth 1 -type f -name "${base_name}.rego" | head -n1)
             if [ -n "$impl_file" ]; then
@@ -67,14 +71,13 @@ runs:
     - name: Run OPA Coverage Tests
       id: opa-coverage
       shell: bash
-      # OPA's CLI for testing and coverage isn't as smart as other languages. Have to manually test each file one by one, and we cannot pass in multiple files at once - you can, but if one fail, the rest won't run. That's not good because we want to test all files and report the result on those, even if one fails. It also cannot find all the files and corresponding test files, hence we have to manually find them dynamically with bash.
       run: |
         BASE_DIRECTORY_PATH="${{ inputs.path }}"
-        tests=$(find "$BASE_DIRECTORY_PATH" -type f -name "*_test.rego")
+        tests=$(find "$BASE_DIRECTORY_PATH" -type f -name "*${{ inputs.test_file_postfix }}.rego")
         output=""
         for test in $tests; do
             echo "Running coverage test: $test"
-            base_name=$(basename "$test" _test.rego)
+            base_name=$(basename "$test" "${{ inputs.test_file_postfix }}.rego")
             test_dir=$(dirname "$test")
             impl_file=$(find "$test_dir" "$test_dir/.." -maxdepth 1 -type f -name "${base_name}.rego" | head -n1)
             if [ -n "$impl_file" ]; then
@@ -99,11 +102,11 @@ runs:
         main_dir="${{ inputs.path }}"
         echo "Searching for untested Rego files in: $main_dir"
 
-        no_test_files=$(find "$main_dir" -type f -name "*.rego" ! -name "*_test.rego" | while read file; do
+        no_test_files=$(find "$main_dir" -type f -name "*.rego" ! -name "*${{ inputs.test_file_postfix }}.rego" | while read file; do
           base_name=$(basename "$file" .rego)
 
           # Search for a corresponding test file anywhere in the project
-          test_file=$(find "$main_dir" -type f -name "${base_name}_test.rego")
+          test_file=$(find "$main_dir" -type f -name "${base_name}${{ inputs.test_file_postfix }}.rego")
 
           if [ -z "$test_file" ]; then
             echo "$file"
@@ -122,8 +125,8 @@ runs:
       run: node ${{ github.action_path }}/dist/index.js
       shell: bash
       # We need to use `env` to pass the inputs into the script. Since this isn't running `with: node` (find the specifics)
-      # we cannot pass it in with 'inputs' in this workflow step with this composite action. THis is a workaround since
-      # GitHub Actions doesn't have a clean way of having a composite action use a custom action within the same repository.
+      # we cannot pass it in with 'inputs' in this workflow step with this composite action.
+      # GitHub Actions doesn't have a direct way of having a composite action use a custom action within the same repository.
       env:
         test_result: ${{ steps.opa-test.outputs.test_result }}
         coverage_result: ${{ steps.opa-coverage.outputs.coverage_result }}

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ branding:
   color: 'green'
 
 inputs:
-  test_directory_path:
+  path:
     description: 'Path to the directory containing OPA Rego files to test. Default to root directory.'
     required: false
     default: '.'
@@ -42,7 +42,7 @@ runs:
       id: opa-test
       shell: bash
       run: |
-        BASE_DIRECTORY_PATH="${{ inputs.test_directory_path }}"
+        BASE_DIRECTORY_PATH="${{ inputs.path }}"
         tests=$(find "$BASE_DIRECTORY_PATH" -type f -name "*_test.rego")
         output=""
         for test in $tests; do
@@ -69,7 +69,7 @@ runs:
       shell: bash
       # OPA's CLI for testing and coverage isn't as smart as other languages. Have to manually test each file one by one, and we cannot pass in multiple files at once - you can, but if one fail, the rest won't run. That's not good because we want to test all files and report the result on those, even if one fails. It also cannot find all the files and corresponding test files, hence we have to manually find them dynamically with bash.
       run: |
-        BASE_DIRECTORY_PATH="${{ inputs.test_directory_path }}"
+        BASE_DIRECTORY_PATH="${{ inputs.path }}"
         tests=$(find "$BASE_DIRECTORY_PATH" -type f -name "*_test.rego")
         output=""
         for test in $tests; do
@@ -96,7 +96,7 @@ runs:
       id: find-no-test
       shell: bash
       run: |
-        main_dir="${{ inputs.test_directory_path }}"
+        main_dir="${{ inputs.path }}"
         echo "Searching for untested Rego files in: $main_dir"
 
         no_test_files=$(find "$main_dir" -type f -name "*.rego" ! -name "*_test.rego" | while read file; do


### PR DESCRIPTION
Changed test_directory_path to path because the path is for the entire dir for rego, not just the test files.

Allow different postfix rather than just _test