### PR TITLE
feat(github-action): add actionlint to lint against gha yamls

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: trunk-io/trunk-action@v1
+
   conventional-commit-title-check:
     runs-on: ubuntu-latest
     permissions:
@@ -28,3 +29,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           requireScope: true
+
+  action-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download actionlint
+        id: get_actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        shell: bash
+      - name: Check workflow files
+        run: ${{ steps.get_actionlint.outputs.executable }} -color
+        shell: bash


### PR DESCRIPTION
## Describe your changes
- Add Actionlint https://github.com/rhysd/actionlint?tab=readme-ov-file which checks the yaml in GitHub Action. Not covered by Trunk because this even checks for syntax in the .yamls