### PR TITLE
fix: pin GitHub Actions to commit SHAs (INT-326)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Trunk Check
-        uses: trunk-io/trunk-action@4d5ecc89b2691705fd08c747c78652d2fc806a94 # v1.1.19
+        uses: trunk-io/trunk-action@75699af9e26881e564e9d832ef7dc3af25ec031b # v1.2.4
 
   conventional-title:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,6 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # 4.1.3
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         with:
           release-type: simple

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: 22
           cache: npm
@@ -22,7 +22,7 @@ jobs:
       - run: npm run build --if-present
       - run: npm test
       - name: Jest Coverage Report
-        uses: ArtiomTr/jest-coverage-report-action@c026e98ae079f4b0b027252c8e957f5ebd420610 # v2.3.0
+        uses: ArtiomTr/jest-coverage-report-action@262a7bb0b20c4d1d6b6b026af0f008f78da72788 # v2.3.1
 
   test-action-on-itself:
     name: Test the GitHub Action on itself
@@ -31,7 +31,7 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Test Local Action (Individual File Mode)
         id: test-action-opa-files

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,12 +2,12 @@
 # To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
 version: 0.1
 cli:
-  version: 1.24.0
+  version: 1.25.0
 # Trunk provides extensibility via plugins. (https://docs.trunk.io/plugins)
 plugins:
   sources:
     - id: trunk
-      ref: v1.7.0
+      ref: v1.7.6
       uri: https://github.com/trunk-io/plugins
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
@@ -23,16 +23,16 @@ lint:
         - dist/**
         - .github/pull_request_template.md
   enabled:
-    - actionlint@1.7.7
-    - checkov@3.2.435
+    - actionlint@1.7.8
+    - checkov@3.2.513
     - git-diff-check
-    - markdownlint@0.45.0
-    - osv-scanner@2.0.2
+    - markdownlint@0.48.0
+    - osv-scanner@2.2.4
     - oxipng@9.1.5
-    - prettier@3.5.3
-    - trivy@0.63.0
-    - trufflehog@3.88.35
-    - yamllint@1.37.1
+    - prettier@3.8.1
+    - trivy@0.69.2
+    - trufflehog@3.90.13
+    - yamllint@1.38.0
 actions:
   enabled:
     - trunk-announce

--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup OPA
-      uses: open-policy-agent/setup-opa@v2
+      uses: open-policy-agent/setup-opa@950f159a49aa91f9323f36f1de81c7f6b5de9576 # v2.3.0
       with:
         version: ${{ inputs.opa_version }}
         static: ${{ inputs.opa_static }}


### PR DESCRIPTION
## Info

- Pins all `uses:` references in GitHub Actions workflows to full commit SHAs.

## References

- https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions