### PR TITLE
chore: use proper trunk upgrade (INT-1582)

### DIFF
--- a/.github/workflows/trunk-upgrade.yaml
+++ b/.github/workflows/trunk-upgrade.yaml
@@ -1,34 +1,24 @@
 name: Trunk Upgrade
 
 on:
-  workflow_call:
-    secrets:
-      MP_BOT_APP_ID:
-        required: true
-      MP_BOT_APP_PRIVATE_KEY:
-        required: true
-      MASTERPOINT_TEAM_PAT:
-        required: true
+  schedule:
+    # On the first day of every month @ 8am
+    - cron: 0 8 1 * *
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 permissions: {}
 
 jobs:
   trunk-upgrade:
-    name: trunk upgrade
-    runs-on: ubuntu-latest
+    uses: masterpointio/actions/.github/workflows/trunk-upgrade.yaml@7dad35e85d864ca5dda0971dfd3c940cc67ed380 #v0.3.0
+    secrets:
+      MP_BOT_APP_ID: ${{ secrets.MP_BOT_APP_ID }}
+      MP_BOT_APP_PRIVATE_KEY: ${{ secrets.MP_BOT_APP_PRIVATE_KEY }}
+      MASTERPOINT_TEAM_PAT: ${{ secrets.MASTERPOINT_TEAM_PAT }}
     permissions:
-      contents: write # needed by github-action-trunk-upgrade to write repository contents
-      pull-requests: write # needed by github-action-trunk-upgrade to write pull requests
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Run Trunk Upgrade
-        uses: masterpointio/github-action-trunk-upgrade@a79fd65d524d92031fe167daee411d2f25d4a999 # v0.1.0
-        with:
-          app-id: ${{ secrets.MP_BOT_APP_ID }}
-          app-private-key: ${{ secrets.MP_BOT_APP_PRIVATE_KEY }}
-          github-token: ${{ secrets.MASTERPOINT_TEAM_PAT }}
-          reviewers: "@masterpointio/masterpoint-open-source"
+      contents: write # needed by github-action-trunk-upgrade
+      pull-requests: write # needed by github-action-trunk-upgrade


### PR DESCRIPTION
## What

- Use proper config for trunk_upgrade

## Why

- Reusable workflow config was pasted here instead of the caller config

## Reminder:

- [INT-1582](https://www.notion.so/masterpoint/Roll-out-Zizmor-across-all-Masterpoint-OSS-repos-08a6992b18de4b9581bec3eb579715b1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation workflows to optimize deployment processes and improve reliability.

---

**Note:** This release contains only internal infrastructure updates with no visible changes to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->